### PR TITLE
design: addUnit props를 전달 받아 after 가상요소 display 여부 스타일 조정

### DIFF
--- a/src/components/Molecules/Price/Price.jsx
+++ b/src/components/Molecules/Price/Price.jsx
@@ -1,8 +1,8 @@
 import { PriceText } from "./PriceStyle";
 
-const Price = ({ size, price, isEmphasized }) => {
+const Price = ({ size, price, isEmphasized, addUnit = true }) => {
   return (
-    <PriceText size={size} isEmphasized={isEmphasized}>
+    <PriceText size={size} isEmphasized={isEmphasized} addUnit={addUnit}>
       {price}
     </PriceText>
   );

--- a/src/components/Molecules/Price/PriceStyle.jsx
+++ b/src/components/Molecules/Price/PriceStyle.jsx
@@ -29,11 +29,20 @@ export const PriceText = styled(SpanEl)`
   color: ${(props) => {
     if (props.isEmphasized) {
       return "var(--emphasized-txt-color)";
+    } else if (!props.addUnit) {
+      return "var(--sub-txt-color)";
     } else {
       return "var(--txt-color)";
     }
   }};
   ::after {
+    display: ${(props) => {
+      if (props.addUnit) {
+        return "inline-block";
+      } else {
+        return "none";
+      }
+    }};
     content: "원";
     font-weight: 400;
     font-size: ${(props) => {


### PR DESCRIPTION
# design: addUnit props를 전달 받아 after 가상요소 display 여부 스타일 조정
#124

## [🍀 무엇을 위한 PR인가요?]
- [ ] 기능 추가 : 
- [x] 디자인 : addUnit props를 전달 받아 after 가상요소 display 여부 스타일 조정
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## [⚠️ 삭제된 파일]

- 

## [✂️ 수정된 파일]

- src/components/Molecules/Price/Price.jsx
- src/components/Molecules/Price/PriceStyle.jsx

## [📝 생성된 파일]

- 

## [🖥️ 스크린샷]


## [📌 제안 사항]

- 모두에게 제안하고 싶은 내용을 작성하여 주세요.
- 해당 안건은 회의시간 안건으로 사용됩니다.

## [📢 Notice]

- 이번 PR에서 모두에게 알리고 싶은 핵심 사항을 작성하여 주세요.
- 해당 섹션은 알림판의 역할을 합니다.

## [이슈 끝내기]
close: #124 
