### PR TITLE
fix: Price props인 isEmphasized의 기본값을 false로 설정하여 필요시에만 props를 전달하도록 간결화

### DIFF
--- a/src/components/Molecules/Price/Price.jsx
+++ b/src/components/Molecules/Price/Price.jsx
@@ -1,6 +1,6 @@
 import { PriceText } from "./PriceStyle";
 
-const Price = ({ size, price, isEmphasized, addUnit = true }) => {
+const Price = ({ size, price, isEmphasized = false, addUnit = true }) => {
   return (
     <PriceText size={size} isEmphasized={isEmphasized} addUnit={addUnit}>
       {price}


### PR DESCRIPTION
# fix: Price props인 isEmphasized의 기본값을 false로 설정하여 필요시에만 props를 전달하도록 간결화
#135

## [🍀 무엇을 위한 PR인가요?]
- [ ] 기능 추가 : 
- [x] 디자인 : Price props인 isEmphasized의 기본값을 false로 설정하여 필요시에만 props를 전달하도록 간결화
- [ ] 리팩토링 : 
- [ ] 문서 수정 : 
- [ ] 버그 수정 : 
- [ ] 테스트 : 
- [ ] 기타 : 

## [⚠️ 삭제된 파일]

- 

## [✂️ 수정된 파일]

- src/components/Molecules/Price/Price.jsx

## [📝 생성된 파일]

- 

## [🖥️ 스크린샷]


## [📌 제안 사항]

- 모두에게 제안하고 싶은 내용을 작성하여 주세요.
- 해당 안건은 회의시간 안건으로 사용됩니다.

## [📢 Notice]

- 이번 PR에서 모두에게 알리고 싶은 핵심 사항을 작성하여 주세요.
- 해당 섹션은 알림판의 역할을 합니다.

## [이슈 끝내기]
close: #135
